### PR TITLE
NotoMono zu NotoSansMono umbenennen.

### DIFF
--- a/source/tudcd-fonts.dtx
+++ b/source/tudcd-fonts.dtx
@@ -141,7 +141,7 @@
   FontFace = {medium}{n}{*-Medium},
   FontFace = {sb}{n}{*-SemiBold}
 ]
-\setmonofont{NotoMono}
+\setmonofont{NotoSansMono}
 
 \renewcommand{\bfdefault}{sb}
 \renewcommand{\mddefault}{medium}


### PR DESCRIPTION
Der Schriftname "NotoMono" ist, soweit ich das überblicken kann, eine Erweiterung von Debian/Ubuntu. Offiziell heißt die Schriftart "NotoSansMono". So ist sie auch unter Arch Linux installiert:

https://archlinux.org/packages/extra/any/noto-fonts/

Unter "View the file list for for noto-fonts" gibt es NotoSansMono-*.ttf, aber nicht NotoMono-*.ttf