### PR TITLE
l_keys_choice_str zu l_keys_choice_tl ändern

### DIFF
--- a/source/tudcd-colors.dtx
+++ b/source/tudcd-colors.dtx
@@ -142,7 +142,7 @@
   color/model .choices:nn = {
     rgb, cmyk
   }{
-    \str_case:VnF\l_keys_choice_str{
+    \str_case:VnF\l_keys_choice_tl{
       {rgb}{
         \tl_set:Nn\l_color_fixed_model_tl{rgb}
       }

--- a/source/tudcd-common.dtx
+++ b/source/tudcd-common.dtx
@@ -365,7 +365,7 @@
   },
   logo/language .choices:nn =
   { de, en, auto }
-  { \str_if_eq:nVTF { auto } { \l_keys_choice_str } {
+  { \str_if_eq:nVTF { auto } { \l_keys_choice_tl } {
       \hook_gput_next_code:nn{package/babel/after}{
         \str_set:Ne \l_@@_logolang_str { \BCPdata{main.language} }
       }
@@ -373,20 +373,20 @@
         \str_set:Ne \l_@@_logolang_str { \BCPdata{main.language} }
       }
     }{
-       \str_set_eq:NN \l_@@_logolang_str \l_keys_choice_str
+       \str_set_eq:NN \l_@@_logolang_str \l_keys_choice_tl
     }
   },
   logo/language .initial:n = { de },
   logo/colormodel .choices:nn =
   { cmyk, rgb }
   {
-    \str_set_eq:NN \l_@@_logomodel_str \l_keys_choice_str
+    \str_set_eq:NN \l_@@_logomodel_str \l_keys_choice_tl
   },
   logo/colormodel .initial:n = { rgb },
   logo/color .choices:nn =
   { blue, white, black }
   {
-    \str_set_eq:NN \l_@@_logocolor_str \l_keys_choice_str
+    \str_set_eq:NN \l_@@_logocolor_str \l_keys_choice_tl
   },
   logo/color .initial:n = { blue },
 %</option&peri&class>

--- a/source/tudcd-geometry.dtx
+++ b/source/tudcd-geometry.dtx
@@ -163,7 +163,7 @@
     poster,
     koma
   }{
-    \str_set_eq:NN \l_@@_geometry_instance_name_str \l_keys_choice_str
+    \str_set_eq:NN \l_@@_geometry_instance_name_str \l_keys_choice_tl
   },
   papelayout .initial:n = { brochure },
   a5paper .code:n = { \str_set:Nn\l_@@_geometry_paper_size_str{a5paper} },
@@ -184,7 +184,7 @@
     a5paper, a4paper
 %<poster>    ,a3paper, a2paper, a1paper, a0paper
   }{
-    \str_set_eq:NN \l_@@_geometry_paper_size_str \l_keys_choice_str
+    \str_set_eq:NN \l_@@_geometry_paper_size_str \l_keys_choice_tl
   },
 %<*article|report|book|thesis>
   usemargin .bool_set:N = \l_@@_geometry_margin_bool,


### PR DESCRIPTION
l_keys_choice_str wurde am 09.10.2025 zum l3kernel Paket hinzugefügt:

https://mirror.funkfreundelandshut.de/latex/macros/latex/required/l3kernel/CHANGELOG.md

Die derzeit aktuelle Version von TeX Live, was unter Arch Linux TeX bereitstellt, ist 2025.2 und enthält l_keys_choice_str noch nicht.

Dieser Commit ersetzt deshalb l_keys_choice_str mit l_keys_choice_tl. Soweit ich das überblicken kann, ist die Funktion identisch.

l_keys_choice_tl ist zwar im gleichen Schritt mit der Einführung von l_keys_choice_str deprecated worden, ich halte das persönlich angesichts der Kompatibilitätsprobleme aber für  das kleinere Übel.

Ich lasse mich aber in dem Punkt gerne überstimmen