### PR TITLE
simplify fontspec config + add support for italics

### DIFF
--- a/source/tudcd-fonts.dtx
+++ b/source/tudcd-fonts.dtx
@@ -180,9 +180,11 @@
 \setmainfont{NotoSerif}
 \setsansfont{NotoSans}
 }{ % Hier ist pdfTeX verwendet worden.
-
-\renewcommand{\bfdefault}{sb}
-\renewcommand{\mddefault}{medium}
+% Leider überschreibt notomath gerade hardcoded die Voreinstellungen.
+% Solange das so ist, muss das hier zusätzlich ausgewählt werden.
+\renewcommand*{\bfdefault}{sb}
+\renewcommand*{\mddefault}{medium}
+}
 %    \end{macrocode}
 %
 % Dabei werden für die Auswahl der einzelnen Schriftschnitte separate Befehle bereitgestellt.


### PR DESCRIPTION
I configured all file names to match the current version of noto within TeX Live + added config for the italics. 

This allows to use the same setup for the custom font commands as used with pdftex which might simplify debugging and should resolve #11. 

Additionally I noticd that notomath is currently hardcoded overwriting some defaults and will report that. I included the mechanism which should work but also kept the workaround you used before. 

Additionally I removed the settings for `\mddefault´ and `\bfdefault` for fontspec, as there one would rather use `UprightFont` and `BoldFont`.